### PR TITLE
Removendo consulta assincrona de grupo que foi substituída pelo scSelect

### DIFF
--- a/src/main/webapp/app/entities/produto/produto-dialog.controller.js
+++ b/src/main/webapp/app/entities/produto/produto-dialog.controller.js
@@ -5,9 +5,9 @@
         .module('gpwebApp')
         .controller('ProdutoDialogController', ProdutoDialogController);
 
-    ProdutoDialogController.$inject = ['$timeout', '$scope', '$stateParams', '$uibModalInstance', '$q', 'DataUtils', 'entity', 'Produto', 'Grupo', 'Marca', 'Unidade', 'ClassProduto', 'NewSelectService'];
+    ProdutoDialogController.$inject = ['$timeout', '$scope', '$stateParams', '$uibModalInstance', '$q', 'DataUtils', 'entity', 'Produto', 'Marca', 'Unidade', 'ClassProduto', 'NewSelectService'];
 
-    function ProdutoDialogController ($timeout, $scope, $stateParams, $uibModalInstance, $q, DataUtils, entity, Produto, Grupo, Marca, Unidade, ClassProduto, NewSelectService) {
+    function ProdutoDialogController ($timeout, $scope, $stateParams, $uibModalInstance, $q, DataUtils, entity, Produto, Marca, Unidade, ClassProduto, NewSelectService) {
         var vm = this;
 
         vm.produto = entity;
@@ -15,18 +15,8 @@
         vm.byteSize = DataUtils.byteSize;
         vm.openFile = DataUtils.openFile;
         vm.save = save;
-        vm.grupos = Grupo.query({filter: 'produto-is-null'});
+        vm.obj = NewSelectService.obj;        
         
-        vm.obj = NewSelectService.obj;
-        
-        $q.all([vm.produto.$promise, vm.grupos.$promise]).then(function() {
-            if (!vm.produto.grupo || !vm.produto.grupo.id) {
-                return $q.reject();
-            }
-            return Grupo.get({id : vm.produto.grupo.id}).$promise;
-        }).then(function(grupo) {
-            vm.grupos.push(grupo);
-        });
         vm.marcas = Marca.query({filter: 'produto-is-null'});
         $q.all([vm.produto.$promise, vm.marcas.$promise]).then(function() {
             if (!vm.produto.marca || !vm.produto.marca.id) {


### PR DESCRIPTION
Antes as entidades com relacionamento usavam uma consulta assíncrona para buscar as entidades relacionadas, por exemplo: ao abrir o cadastro de produto o sistema carregava todos os grupos, porém isso é enviável para um sistema grande, então o componentes select novo que criei resolve isso, buscando os dados com paginação e só quando solicitado.
